### PR TITLE
Added note on 'when' option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ depsInDirection(station, direction, [opt])
 	concurrency: 4, // max nr. of parallel requests
 	results: 10, // nr. of results to collect
 	maxQueries: 10, // max nr. of requests
-	when: 0 // time in ms to offset departure time
+	when: 0 // time in ms since epoch
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,8 @@ depsInDirection(station, direction, [opt])
 {
 	concurrency: 4, // max nr. of parallel requests
 	results: 10, // nr. of results to collect
-	maxQueries: 10 // max nr. of requests
+	maxQueries: 10, // max nr. of requests
+	when: 0 // time in ms to offset departure time
 }
 ```
 


### PR DESCRIPTION
Turns out, 'when' is supported already as a number of milliseconds added to Date.now(), it's just missing from the readme. Closes #3